### PR TITLE
move js-yaml to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "eslint": "^7.0.0",
+    "js-yaml": "^4.0.0",
     "mocha": "^7.1.2",
     "nyc": "^15.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
   },
   "devDependencies": {
     "eslint": "^7.0.0",
-    "js-yaml": "^4.0.0",
     "mocha": "^7.1.2",
     "nyc": "^15.1.0"
   },
   "dependencies": {
     "esprima": "^4.0.1"
+  },
+  "peerDependencies": {
+    "js-yaml": "4.x"
   }
 }


### PR DESCRIPTION
Ensure the right version and instance of js-yaml is used rather than an older hoisted version from projects that are still using the older v3.14 version of js-yaml.

fixes: #2